### PR TITLE
Remove array usage for string and make file writing asynchronous.

### DIFF
--- a/ConsoleApp1/Modules/f.cs
+++ b/ConsoleApp1/Modules/f.cs
@@ -24,13 +24,10 @@ public class f : ModuleBase<SocketCommandContext>
         count++;
 
         //Convert count to string type
-        string[] stringcount;
-        stringcount = new string[1];
+        string stringcount = count.ToString();
 
-        //Convert to string array because File.WriteAllLines() takes in string[] not string
-        stringcount[0] = count.ToString();
-
-        File.WriteAllLines("fcount.txt", stringcount);
+        // Write new count to file
+        await File.WriteAllTextAsync("fcount.txt", stringcount);
 
     }
 }


### PR DESCRIPTION
No reason to have the string be contained in a 1-length array.
Also no reason to have the method be `async` if you're not going to `await` for the file write.